### PR TITLE
Update index.js

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -11,6 +11,7 @@ let COORDSCALE = 2**19 / 16 * window.devicePixelRatio;
 //let _getTileUrl = L.TileLayer.prototype.getTileUrl;
 //L.TileLayer.prototype.getTileUrl = function(coords) { return _getTileUrl.call(this, {x: coords.x - 1 * Math.pow(2, coords.z - 2), y: coords.y, z: coords.z}); };
 
+
 L.TileLayer.prototype.getTileUrl = function(c) {
 	let mapIndex = this.tileIndex[c.z] && this.tileIndex[c.z][c.y] && this.tileIndex[c.z][c.y][c.x];
 	if (isNaN(mapIndex))
@@ -22,6 +23,9 @@ L.TileLayer.prototype.getTileUrl = function(c) {
 
 //TODO: iterate over surfaces
 //let surface = Object.keys(mapInfo.maps[0].surfaces)[0];
+
+// Reorder maps by their time
+mapInfo['maps'].sort((a,b) => parseInt(a.path) > parseInt(b.path) ? 1 : -1);
 
 
 let layers = [], saves = [], countAvailableSaves = 0, layersByTimestamp = [], labels = [];


### PR DESCRIPTION
Reorder the maps by their time so the vertical map slider show layers ordered by their save time rather by their generation time

Situation : if you generate three maps for the same save in incorrect order (lets say 1h, 10h and 9h), the map will show you the slider in this order 

![image](https://user-images.githubusercontent.com/5570178/69899576-97a63480-1368-11ea-8ff0-e5c01bd04658.png)

With the fix : the slider will have its natural order

![image](https://user-images.githubusercontent.com/5570178/69899570-8b21dc00-1368-11ea-94aa-33a07de32c75.png)

