### PR TITLE
Fix maps saved in editor mode not working

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -255,7 +255,9 @@ script.on_event(defines.events.on_tick, function(event)
 
 		game.tick_paused = true
 		game.ticks_to_run = 0
-		player.character.active = false
+		if player.character ~= nil then
+			player.character.active = false
+		end
 		
 		local main = player.gui.center.add{type = "frame", caption = text[1], direction = "vertical"}
 		local topLine = main.add{type = "flow", direction = "horizontal"}
@@ -286,3 +288,8 @@ script.on_event(defines.events.on_tick, function(event)
 		
 	end
 end)
+function unpause()
+	game.tick_paused = false
+end
+script.on_init(unpause)
+script.on_load(unpause)


### PR DESCRIPTION
If a map is saved with editor mode enabled, then player.character doesn't exist. It also unpauses the map which otherwise would prevent the `on_tick` event from firing.