### PR TITLE
Fix PermissionError exception in 'availableDrives'

### DIFF
--- a/auto.py
+++ b/auto.py
@@ -447,9 +447,15 @@ def auto(*args):
 		"Program Files (x86)/Steam/steamapps/common/Factorio/bin/x64/factorio.exe",
 		"Steam/steamapps/common/Factorio/bin/x64/factorio.exe",
 	]
+	
+	def driveExists(drive):
+		try:
+			return Path(f"{drive}:/").exists()
+		except PermissionError:
+			return False
 
 	availableDrives = [
-		"%s:/" % d for d in string.ascii_uppercase if Path(f"{d}:/").exists()
+		"%s:/" % d for d in string.ascii_uppercase if driveExists(d)
 	]
 	possiblePaths = [
 		drive + path for drive in availableDrives for path in windowsPaths


### PR DESCRIPTION
This line throws `PermissionError` for my Windows:

https://github.com/L0laapk3/FactorioMaps/blob/bd08875c83b0f632aca7411f358e511abdbb4313/auto.py#L452

so I just wrapped it with try-except.

In detail, this line throws exception when it tries to access an empty CD-ROM drive (`D:\` in my case).