### PR TITLE
Fix mod zip folder names

### DIFF
--- a/auto.py
+++ b/auto.py
@@ -819,7 +819,8 @@ def auto(*args):
 							zipPath = os.path.join(args.basepath, args.mod_path, mod[2] + ".zip")
 							with ZipFile(zipPath, 'r') as zipObj:
 								if len(icons) == 1:
-									zipInfo = zipObj.getinfo(os.path.join(mod[2], icon + ".png").replace('\\', '/'))
+									internalFolder = os.path.commonpath(zipObj.namelist())
+									zipInfo = zipObj.getinfo(os.path.join(internalFolder, icon + ".png").replace('\\', '/'))
 									zipInfo.filename = os.path.basename(dest)
 									zipObj.extract(zipInfo, os.path.dirname(os.path.realpath(dest)))
 									src = None

--- a/auto.py
+++ b/auto.py
@@ -748,6 +748,14 @@ def auto(*args):
 			os.remove(os.path.join(workfolder, "mapInfo.out.json"))
 
 
+		# List of length 3 tuples:
+		#   mod name in lowercase (e.g. `krastorio2`, `fnei`)
+		#   (major version string, minor version string, patch version string, bool if the mod's a zipfile)
+		#   mod full ID in original casing (e.g. `Krastorio2_1.1.4`, `FNEI_0.4.1`)
+		#
+		# Does not include mods that don't have versions in
+		# their names, such as mods manually installed from
+		# source.
 		modVersions = sorted(
 				map(lambda m: (m.group(2).lower(), (m.group(3), m.group(4), m.group(5), m.group(6) is None), m.group(1)),
 					filter(lambda m: m,


### PR DESCRIPTION
[The wiki](https://wiki.factorio.com/Tutorial:Mod_structure) says that the a zip must contain a single folder and that that folder can be named anything. As such, attempting to guess the folder name from information we have (e.g. the mod name) will inevitably have failures when mod authors don't follow the implicit practice of naming that internal folder after the mod. The solution is to list out the contents of the zipfile and feed those to `os.path.commonpath` to obtain that single root directory.

Also committed some comments I wrote for myself when I was trying to figure out what the code was doing.

Fixes #99