### PR TITLE
Fix OSError/PermissionError exception in 'availableDrives'

### DIFF
--- a/auto.py
+++ b/auto.py
@@ -464,8 +464,13 @@ def auto(*args):
 			"Program Files (x86)/Steam/steamapps/common/Factorio/bin/x64/factorio.exe",
 			"Steam/steamapps/common/Factorio/bin/x64/factorio.exe",
 		]
+		def driveExists(drive):
+			try:
+				return Path(f"{drive}:/").exists()
+			except (OSError, PermissionError):
+				return False
 		availableDrives = [
-			"%s:/" % d for d in string.ascii_uppercase if Path(f"{d}:/").exists()
+			"%s:/" % d for d in string.ascii_uppercase if driveExists(d)
 		]
 		possibleFactorioPaths = unixPaths
 		if args.steam == 0:


### PR DESCRIPTION
[This commit](https://github.com/L0laapk3/FactorioMaps/commit/6fa5885d0285988110a8ea639520fff8504f86a5) discarded changes from PR #83, so I reapplied changes from the PR.
Also fixes #104 by adding `OSError` to the exception list.