### PR TITLE
Support savegames located in subdirectories

### DIFF
--- a/auto.py
+++ b/auto.py
@@ -442,7 +442,7 @@ def auto(*args):
 			raise IOError(f"savefile {saveName!r} not found in {str(saves)!r}")
 		results = [save for save in globResults if save.is_file()]
 		for result in results:
-			saveGames.add(result.stem)
+			saveGames.add(result.relative_to(saves).as_posix())
 
 	saveGames = naturalSort(list(saveGames))
 
@@ -566,7 +566,7 @@ def auto(*args):
 
 					launchArgs = [
 						'--load-game',
-						str(Path(userFolder, 'saves', savename).absolute()),
+						str(Path(userFolder, 'saves', *(savename.split('/'))).absolute()),
 						'--disable-audio',
 						'--config',
 						str(configPath),


### PR DESCRIPTION
Did you know: [you can create subdirectories in the savefile directory and organize savegames](https://www.reddit.com/r/factorio/comments/av8uda/til_you_can_organize_your_save_files_under/)?
This commit supports such functionality.
For example:
```bash
python auto.py mapname subdir/savegame
```
works if the savegame is located as `.../Factorio/saves/subdir/savegame.zip`.