### PR TITLE
Updates requirements.txt to a newer version of Pillow, as necessary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyTurboJPEG>=1.1.5
 psutil>=5.4.8
 numpy>=1.16.4
-Pillow>=6.1.0
+Pillow>=9.3.0
 setuptools>=68.0.0


### PR DESCRIPTION
The script now uses functions of Pillow that haven't been in 6.1.0 for some time. This probably doesn't change anything if you use the --update command as suggested, but is more explicit for clarity if nothing else.